### PR TITLE
Allow for "/" in jobs in order to enable multibranch/pipeline builds

### DIFF
--- a/tools/tschenggins-status.pl
+++ b/tools/tschenggins-status.pl
@@ -41,7 +41,7 @@ my $DATADIR       = $FindBin::Bin;
 my $VALIDRESULT   = { unknown => 1, success => 2, unstable => 3, failure => 4 };
 my $VALIDSTATE    = { unknown => 1, running => 2, idle => 3 };
 my $UNKSTATE      = { name => 'unknown', server => 'unknown', result => 'unknown', state => 'unknown', ts => time() };
-my $JOBNAMERE     = qr{^[-_a-zA-Z0-9]{5,50}$};
+my $JOBNAMERE     = qr{^[-_a-zA-Z1-9\/]{5,50}$};
 my $JOBIDRE       = qr{^[0-9a-z]{8,8}$};
 my $DEFAULTCMD    = 'gui';
 my $DBFILE        = $ENV{'REMOTE_USER'} ? "$DATADIR/tschenggins-status-$ENV{'REMOTE_USER'}.json" : "$DATADIR/tschenggins-status.json";

--- a/tools/tschenggins-status.pl
+++ b/tools/tschenggins-status.pl
@@ -41,7 +41,7 @@ my $DATADIR       = $FindBin::Bin;
 my $VALIDRESULT   = { unknown => 1, success => 2, unstable => 3, failure => 4 };
 my $VALIDSTATE    = { unknown => 1, running => 2, idle => 3 };
 my $UNKSTATE      = { name => 'unknown', server => 'unknown', result => 'unknown', state => 'unknown', ts => time() };
-my $JOBNAMERE     = qr{^[-_a-zA-Z1-9\/]{5,50}$};
+my $JOBNAMERE     = qr{^[-_a-zA-Z1-9/]{5,50}$};
 my $JOBIDRE       = qr{^[0-9a-z]{8,8}$};
 my $DEFAULTCMD    = 'gui';
 my $DBFILE        = $ENV{'REMOTE_USER'} ? "$DATADIR/tschenggins-status-$ENV{'REMOTE_USER'}.json" : "$DATADIR/tschenggins-status.json";


### PR DESCRIPTION
So far it was not allowed to have "/" in job names.
I changed this in order to allow for the different directory structure
of multibranch builds.
E.g. where normally you would have "JOB/builds" in multibranch builds
one has "JOB/branches/BRANCH/builds/".
This change will allow adding such jobs.
It seems like there is no change needed to tschenggins-watcher.pl.
Experimenting with this structure suggests that it sucessfully parses for
result messages